### PR TITLE
Include Nekro Dimensional Tears in Vuil'raith Hero

### DIFF
--- a/TI4/Helpers/TI4_FactionHelper.ttslua
+++ b/TI4/Helpers/TI4_FactionHelper.ttslua
@@ -1681,14 +1681,16 @@ function _carrionHeroAbilityCoroutine()
     end
     assert(factionTokenName and factionColor, 'Dimensional Anchor: Trying to invoke Hero Ability, but no faction with "It Feeds on Carrion" is at the table.')
 
-    --Find each dimensional tear token (Cabal only)
-    local dimensionalTearName = "Tear Token (Cabal)"
+    --Find each dimensional tear token (Cabal and Nekro)
     local dimTokenToPosition = {}
     local anyDimensionalTears = false
     for _, object in ipairs(getAllObjects()) do
-        if object.tag == 'Tile' and object.getName() == dimensionalTearName then
-            dimTokenToPosition[object.getGUID()] = object.getPosition()
-            anyDimensionalTears = true
+        if object.tag == 'Tile' then
+            local objname = object.getName()
+            if objname == 'Tear Token (Cabal)' or objname == 'Tear Token (Nekro)' then
+                dimTokenToPosition[object.getGUID()] = object.getPosition()
+                anyDimensionalTears = true
+            end
         end
     end
     coroutine.yield(0)


### PR DESCRIPTION
As per the #ti4-rules-discussion channel, the Vuil'raith hero should take into account all Dimensional Tears, including those owned by the Nekro player.
![image](https://user-images.githubusercontent.com/42644678/135703338-34074ad2-2fe1-4d79-aa9c-fa1dad35f052.png)
This change implements this ruling.
Based off of the https://github.com/darrellanderson/TI4-TTS/blob/30b9b663ae8612b11421107601b051b0dfde5eba/TI4/Helpers/StandAlone/TI4_RiftRoller.ttslua#L69-L74 code.
This change is untested.