### PR TITLE
Add slice offsets to the Milty Draft for other player counts

### DIFF
--- a/TI4/DraftTools/MiltyDraft.ttslua
+++ b/TI4/DraftTools/MiltyDraft.ttslua
@@ -1988,15 +1988,36 @@ end
 
 Slice = {
     -- Slice is a mini-map string with tiles in this order.
-    OFFSETS = {
+    OFFSETS = { -- the default for most players
         { name = 'leftOfHome', x = -1, z = 0.5 },
         { name = 'frontOfHome', x = 0, z = 1 },
         { name = 'rightOfHome', x = 1, z = 0.5 },
         { name = 'leftEquidistant', x = -1, z = 1.5 },
         { name = 'frontFurther', x = 0, z = 2 },
+    },
+    -- TODO: implement the following offsets
+    OFFSETS_HYPER = { -- for any player with a ring of hyperlanes replacing the slice to their left
+        { name = 'leftOfHome', x = -1, z = 0.5 },
+        { name = 'frontOfHome', x = 0, z = 1 },
+        { name = 'rightOfHome', x = 1, z = 0.5 },
+        { name = 'leftEquidistant', x = -2, z = 2 },
+        { name = 'frontFurther', x = 0, z = 2 },
+    },
+    OFFSETS_7C_8CG = { -- for the seven and eight player maps, for the players that have 83B/85B where the frontOfHome tile would usually be
+        { name = 'leftOfHome', x = -1, z = 0.5 },
+        { name = 'frontOfHome', x = 1, z = 1.5 },
+        { name = 'rightOfHome', x = 1, z = 0.5 },
+        { name = 'leftEquidistant', x = 0, z = 2 },
+        { name = 'frontFurther', x = 1, z = 2.5 },
+    },
+    OFFSETS_7E = { -- for the seven player map; for the player that has 88B where the leftEquidistant tile would usually be
+        { name = 'leftOfHome', x = -1, z = 0.5 },
+        { name = 'frontOfHome', x = 0, z = 1 },
+        { name = 'rightOfHome', x = 1, z = 0.5 },
+        { name = 'leftEquidistant', x = -1, z = 2.5 },
+        { name = 'frontFurther', x = 0, z = 2 },
     }
 }
-
 --- Compute "R/I TECH LEGENDARY" label from a list of tile numbers.
 function Slice.getSummary(tiles)
     local valid = {}


### PR DESCRIPTION
This adds the offsets for the hexes that make up each slice when not playing with exactly six players.
`OFFSETS_HYPER` has the offsets for when the standard ring of 83A-88A hyperlanes are to the left of a player, when there are 5 or fewer players.
`OFFSETS_7C_8CG` has the offsets for some players in the seven and eight player maps. If the bottom player in the rulebook map images is player "A", and the other players are labelled clockwise, then these offsets are for player C in seven and eight player games, as well as player G in eight player games. These players have the 83B/85B hyperlane tiles directly in front of their home system.
`OFFSETS_7E` has the offsets for player E in the seven player map following the labelling above. They have the 88B hyperlane tile where their equidistant would be.
This change does not implement these offsets into the tool, only provides the positions for a later change to implement.